### PR TITLE
adh branding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -183,7 +183,7 @@ visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public
 
 
 ###########################################
-# OSIsoft Code Style Rules                #
+# AVEVA Code Style Rules                #
 # NOTE: Requires **VS2019 16.3** or later #
 ###########################################
 [*.{cs,vb}]
@@ -557,7 +557,7 @@ dotnet_diagnostic.SX1309S.severity = error
 
 
 ###########################################
-# OSIsoft Code Analysis Rules             #
+# AVEVA Code Analysis Rules             #
 # NOTE: Requires **VS2019 16.3** or later #
 ###########################################
 # CA1000: Do not declare static members on generic types
@@ -1057,7 +1057,7 @@ dotnet_diagnostic.IL3001.severity = error
 ####################################################################
 # Team-specific Rules, Extensions, and Overrides
 # Description:
-#   Rules from the common OSIsoft rules may be overridden here.
+#   Rules from the common AVEVA rules may be overridden here.
 #   Extensions to enable additional rules is always acceptable.
 #   Overrides do disable a rule are by exception only and should
 #   include one of the following:

--- a/DataViews/DataViews.csproj
+++ b/DataViews/DataViews.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="OSIsoft.OCSClients" Version="4.0.5-prerelease-20211025.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DataViews/DataViews.csproj
+++ b/DataViews/DataViews.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="OSIsoft.OCSClients" Version="4.0.5-prerelease-20211025.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/DataViews/Program.cs
+++ b/DataViews/Program.cs
@@ -81,9 +81,9 @@ namespace DataViews
                 var uriResource = new Uri(resource);
                 #endregion // configurationSettings
 
-                // Step 1 - Authenticate Against OCS
+                // Step 1 - Authenticate Against ADH
                 #region step1
-                Console.WriteLine("Step 1: Authenticate Against OCS");
+                Console.WriteLine("Step 1: Authenticate Against ADH");
 
                 var sdsService = new SdsService(new Uri(resource), new AuthenticationHandler(uriResource, clientId, clientSecret));
                 metadataService = sdsService.GetMetadataService(tenantId, namespaceId);
@@ -440,7 +440,7 @@ namespace DataViews
             }
             finally
             {
-                // Step 15 - Delete Sample Objects from OCS
+                // Step 15 - Delete Sample Objects from ADH
                 #region step15
 
                 if (dataviewService != null)
@@ -457,7 +457,7 @@ namespace DataViews
                 if (metadataService != null)
                 {
                     // Delete everything
-                    Console.WriteLine("Step 14: Delete Sample Objects from OCS");
+                    Console.WriteLine("Step 14: Delete Sample Objects from ADH");
                     await RunInTryCatch(metadataService.DeleteStreamAsync, sampleStreamId1).ConfigureAwait(false);
                     await RunInTryCatch(metadataService.DeleteStreamAsync, sampleStreamId2).ConfigureAwait(false);
                     await RunInTryCatch(metadataService.DeleteTypeAsync, sampleTypeId1).ConfigureAwait(false);

--- a/DataViews/VerbosityHeaderHandler.cs
+++ b/DataViews/VerbosityHeaderHandler.cs
@@ -21,7 +21,7 @@ namespace DataViews
                 throw new ArgumentNullException(nameof(request));
             }
 
-            // If the handler is set to non-verbose, set the accept-verbosity header to non-verbose to prevent null values from being returned from OCS
+            // If the handler is set to non-verbose, set the accept-verbosity header to non-verbose to prevent null values from being returned from ADH
             if (!Verbose)
             {
                 request?.Headers.Add("accept-verbosity", "non-verbose");

--- a/DataViews/appsettings.placeholder.json
+++ b/DataViews/appsettings.placeholder.json
@@ -1,5 +1,5 @@
 {
-  "Resource": "https://dat-b.osisoft.com",
+  "Resource": "https://uswe.datahub.connect.aveva.com",
   "TenantId": "PLACEHOLDER_REPLACE_WITH_TENANT_ID",
   "NamespaceId": "PLACEHOLDER_REPLACE_WITH_NAMESPACE_ID",
   "ClientId": "PLACEHOLDER_REPLACE_WITH_CLIENT_ID",

--- a/DataViewsTests/DataViewsTests.csproj
+++ b/DataViewsTests/DataViewsTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/DataViewsTests/DataViewsTests.csproj
+++ b/DataViewsTests/DataViewsTests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,13 +1,16 @@
 # Version History
 
-## 1.3.0 / 2022-10-14
+## 1.3.1 / 2022-02-02
+
+- Updated dependencies
+
+## 1.3.0 / 2022-01-14
 
 - Added step 14: demonstration of accept-verbosity: non-verbose header
 
 ## 1.2.3 / 2022-01-12
 
 - Updated dependencies
-
 
 ## 1.2.2 / 2021-10-21
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## 1.3.1 / 2022-02-02
 
+- Updated for AVEVA Data Hub
 - Updated dependencies
 
 ## 1.3.0 / 2022-01-14

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Version:** 1.3.0
 
-[![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/aveva.sample-adh-data_views-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3541&branchName=main)
+[![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-data_views-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3541&branchName=main)
 
 The sample code in this topic demonstrates how to invoke the ADH client library. The sample demonstrates how to establish a connection to SDS, obtain an authorization token, create an SdsType and SdsStream with data (if needed), create a Data View, update it, retrieve it, and retrieve data from it in different ways. At the end of the sample, everything that was created is deleted.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# Using OCS Data Views in .NET
+# Using ADH Data Views in .NET
+
+| :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub.  The samples also work on OSIsoft Cloud Services unless otherwise noted. |
+| -----------------------------------------------------------------------------------------------|  
 
 **Version:** 1.3.0
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/osisoft.sample-ocs-data_views-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3541&branchName=main)
 
-The sample code in this topic demonstrates how to invoke the OCS client library. The sample demonstrates how to establish a connection to SDS, obtain an authorization token, create an SdsType and SdsStream with data (if needed), create a Data View, update it, retrieve it, and retrieve data from it in different ways. At the end of the sample, everything that was created is deleted.
+The sample code in this topic demonstrates how to invoke the ADH client library. The sample demonstrates how to establish a connection to SDS, obtain an authorization token, create an SdsType and SdsStream with data (if needed), create a Data View, update it, retrieve it, and retrieve data from it in different ways. At the end of the sample, everything that was created is deleted.
 
-When working in .NET, it is recommended that you use the OCS Client Libraries metapackage, OSIsoft.OCSClients. The metapackage is a NuGet package available from [https://api.nuget.org/v3/index.json](https://api.nuget.org/v3/index.json). The libraries offer a framework of classes that make client development easier.
+When working in .NET, it is recommended that you use the ADH Client Libraries metapackage, OSIsoft.OCSClients. The metapackage is a NuGet package available from [https://api.nuget.org/v3/index.json](https://api.nuget.org/v3/index.json). The libraries offer a framework of classes that make client development easier.
 
 [SDS documentation](https://ocs-docs.osisoft.com/Content_Portal/Documentation/SequentialDataStore/Data_Store_and_SDS.html)
 
@@ -36,13 +39,13 @@ dotnet test
 
 The sample is configured using the file [appsettings.placeholder.json](DataViews/appsettings.placeholder.json). Before editing, rename this file to `appsettings.json`. This repository's `.gitignore` rules should prevent the file from ever being checked in to any fork or branch, to ensure credentials are not compromised.
 
-The SDS Service is secured by obtaining tokens from Azure Active Directory. Such clients provide a client Id and an associated secret (or key) that are authenticated against the directory. You must replace the placeholders in the `appsettings.json` file with the authentication-related values you received from OSIsoft.
+The SDS Service is secured by obtaining tokens from Azure Active Directory. Such clients provide a client Id and an associated secret (or key) that are authenticated against the directory. You must replace the placeholders in the `appsettings.json` file with the authentication-related values you received from AVEVA.
 
 ```json
 {
   "NamespaceId": "PLACEHOLDER_REPLACE_WITH_NAMESPACE_ID",
   "TenantId": "PLACEHOLDER_REPLACE_WITH_TENANT_ID",
-  "Resource": "https://dat-b.osisoft.com",
+  "Resource": "https://uswe.datahub.connect.aveva.com",
   "ClientId": "PLACEHOLDER_REPLACE_WITH_CLIENT_IDENTIFIER",
   "ClientSecret": "PLACEHOLDER_REPLACE_WITH_CLIENT_SECRET",
   "ApiVersion": "v1"
@@ -53,6 +56,6 @@ The SDS Service is secured by obtaining tokens from Azure Active Directory. Such
 
 Tested against DotNet 5.0.
 
-For the main OCS data views samples page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS/blob/main/docs/DATA_VIEWS.md)  
-For the main OCS samples page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS)  
-For the main OSIsoft samples page [ReadMe](https://github.com/osisoft/OSI-Samples)
+For the main ADH data views samples page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS/blob/main/docs/DATA_VIEWS.md)  
+For the main ADH samples page [ReadMe](https://github.com/osisoft/OSI-Samples-OCS)  
+For the main AVEVA samples page [ReadMe](https://github.com/osisoft/OSI-Samples)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :loudspeaker: **Notice**: Samples have been updated to reflect that they work on AVEVA Data Hub.  The samples also work on OSIsoft Cloud Services unless otherwise noted. |
 | -----------------------------------------------------------------------------------------------|  
 
-**Version:** 1.3.0
+**Version:** 1.3.1
 
 [![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/ADH/aveva.sample-adh-data_views-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3541&branchName=main)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Version:** 1.3.0
 
-[![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/osisoft.sample-ocs-data_views-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3541&branchName=main)
+[![Build Status](https://dev.azure.com/osieng/engineering/_apis/build/status/product-readiness/aveva.sample-adh-data_views-dotnet?branchName=main)](https://dev.azure.com/osieng/engineering/_build/latest?definitionId=3541&branchName=main)
 
 The sample code in this topic demonstrates how to invoke the ADH client library. The sample demonstrates how to establish a connection to SDS, obtain an authorization token, create an SdsType and SdsStream with data (if needed), create a Data View, update it, retrieve it, and retrieve data from it in different ways. At the end of the sample, everything that was created is deleted.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 jobs:
   - job: Tests
     strategy:
-      maxParallel: 1 # Avoid conflicts in OCS
+      maxParallel: 1 # Avoid conflicts in ADH
       matrix:
         linux:
           agentOS: Linux
@@ -48,7 +48,7 @@ jobs:
     steps:
       - template: '/miscellaneous/build_templates/appsettings.yml@templates'
         parameters:
-          secrets: 'TenantId, NamespaceId, ClientId, ClientSecret'
+          secrets: 'TenantId, NamespaceId, ClientId, ClientSecret, Resource'
 
       - task: DotNetCoreCLI@2
         displayName: 'Nuget restore'


### PR DESCRIPTION
This PR changes cosmetic branding from OSIsoft and OCS to AVEVA and ADH.

## What's Included
Following has been updated
* README link resources
* Company name
* OCS mentions
* Link titles
* Cloud portal links
* Sample library ref
* Resource in placeholder
 
The following is not included in this update
* History files
* GitHub links
* Build references
* Currently dead links such as ocs-docs (Will investigate best practice here) and OCS Overview pages (There is an option for this here https://www.aveva.com/content/dam/aveva/documents/datasheets/Datasheet_AVEVA_DataHubAnnouncementand_FAQ_10-21.pdf
* Copyright and License files


Let me know if anything is missing or incorrect above.